### PR TITLE
Improve slot schema validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/platform-browser-dynamic": "^21.1.5",
         "@angular/router": "^21.1.5",
         "@luzmo/analytics-components-kit": "^1.0.1-alpha.140",
-        "@luzmo/dashboard-contents-types": "^1.0.27",
+        "@luzmo/dashboard-contents-types": "1.0.31",
         "@luzmo/icons": "^1.0.1-alpha.33",
         "@luzmo/lucero": "^1.0.1-alpha.62",
         "@ng-bootstrap/ng-bootstrap": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@angular/platform-browser-dynamic": "^21.1.5",
     "@angular/router": "^21.1.5",
     "@luzmo/analytics-components-kit": "^1.0.1-alpha.140",
-    "@luzmo/dashboard-contents-types": "^1.0.27",
+    "@luzmo/dashboard-contents-types": "1.0.31",
     "@luzmo/icons": "^1.0.1-alpha.33",
     "@luzmo/lucero": "^1.0.1-alpha.62",
     "@ng-bootstrap/ng-bootstrap": "^20.0.0",

--- a/projects/builder/src/app/slot-schema.ts
+++ b/projects/builder/src/app/slot-schema.ts
@@ -1,114 +1,78 @@
+import type {
+  ColumnSubtype,
+  ColumnType,
+  FormulaSubtype,
+  FormulaType,
+  SlotConfig,
+  SlotName
+} from '@luzmo/dashboard-contents-types';
 import { z } from 'zod';
 
+const slotNameSchema = z.string().min(1) as z.ZodType<SlotName>;
+const slotNameArraySchema = z.array(slotNameSchema);
+
+const dataFieldTypeSchema = z.enum([
+  'array[datetime]',
+  'array[hierarchy]',
+  'array[numeric]',
+  'array[spatial]',
+  'datetime',
+  'hierarchy',
+  'numeric',
+  'spatial'
+]) as z.ZodType<ColumnType | FormulaType>;
+
+const dataFieldSubtypeSchema = z.enum([
+  'coordinates',
+  'currency',
+  'duration',
+  'hierarchy_element_expression',
+  'interval',
+  'ip_address',
+  'topography'
+]) as z.ZodType<ColumnSubtype | FormulaSubtype>;
+
 /**
- * Generated from FE types in frontend/libs/dashboard-contents-types/src/lib/shared/slots.ts:SlotConfig
+ * Generated from @luzmo/dashboard-contents-types:SlotConfig.
  *
  * @todo: Extract to common folder
  */
-export const SlotsConfigSchema = z
-  .object({
-    name: z.enum([
-      'x-axis',
-      'y-axis',
-      'category',
-      'measure',
-      'coordinates',
-      'legend',
-      'geo',
-      'image',
-      'color',
-      'levels',
-      'slidermetric',
-      'dimension',
-      'destination',
-      'source',
-      'time',
-      'identifier',
-      'target',
-      'size',
-      'name',
-      'columns',
-      'column',
-      'row',
-      'evolution',
-      'close',
-      'open',
-      'low',
-      'high',
-      'order',
-      'route'
-    ]),
-    position: z.enum(['top-left', 'top', 'top-right', 'right', 'bottom-right', 'bottom', 'bottom-left', 'left', 'middle']).optional(),
-    label: z.union([z.string(), z.record(z.string(), z.string())]).optional(),
-    description: z.string().optional(),
-    type: z.enum(['numeric', 'categorical', 'mixed']).optional(),
-    order: z.number().optional(),
-    acceptableColumnTypes: z
-      .array(z.enum(['numeric', 'hierarchy', 'datetime', 'spatial']))
-      .optional(),
-    acceptableColumnSubtypes: z
-      .array(
-        z.enum([
-          'duration',
-          'currency',
-          'coordinates',
-          'hierarchy_element_expression',
-          'topography',
-          'ip_address'
-        ])
-      )
-      .optional(),
-    canAcceptFormula: z.boolean().optional(),
-    rotate: z.boolean().optional(),
-    canAcceptMultipleColumns: z.boolean().optional(),
-    requiredMinimumColumnsCount: z.number().optional(),
-    isRequired: z.boolean().optional(),
-    isHidden: z.boolean().optional(),
-    noMultipleIfSlotsFilled: z
-      .array(
-        z.enum([
-          'x-axis',
-          'y-axis',
-          'category',
-          'measure',
-          'coordinates',
-          'legend',
-          'geo',
-          'image',
-          'color',
-          'levels',
-          'slidermetric',
-          'dimension',
-          'destination',
-          'source',
-          'time',
-          'identifier',
-          'target',
-          'size',
-          'name',
-          'columns',
-          'column',
-          'row',
-          'evolution',
-          'close',
-          'open',
-          'low',
-          'high',
-          'order',
-          'route'
-        ])
-      )
-      .optional(),
-    options: z
-      .object({
-        isBinningDisabled: z.boolean().optional(),
-        isAggregationDisabled: z.boolean().optional(),
-        areGrandTotalsEnabled: z.boolean().optional(),
-        showOnlyFirstSlotGrandTotals: z.boolean().optional(),
-        isCumulativeSumEnabled: z.boolean().optional(),
-        areDatetimeOptionsEnabled: z.boolean().optional(),
-        showOnlyFirstSlotContentOptions: z.boolean().optional()
-      })
-      .optional()
-  })
-  .array();
+const slotConfigShape = {
+  name: slotNameSchema,
+  position: z.enum(['top-left', 'top', 'top-right', 'right', 'bottom-right', 'bottom', 'bottom-left', 'left', 'middle']).optional(),
+  label: z.union([z.string(), z.record(z.string(), z.string())]).optional(),
+  description: z.string().optional(),
+  type: z.enum(['numeric', 'categorical', 'mixed']).optional(),
+  order: z.number().optional(),
+  acceptableDataFieldTypes: z.array(dataFieldTypeSchema).optional(),
+  acceptableColumnTypes: z.array(dataFieldTypeSchema).optional(),
+  acceptableColumnSubtypes: z.array(dataFieldSubtypeSchema).optional(),
+  canAcceptFormula: z.boolean().optional(),
+  rotate: z.boolean().optional(),
+  canAcceptMultipleDataFields: z.boolean().optional(),
+  canAcceptMultipleColumns: z.boolean().optional(),
+  requiredMinimumColumnsCount: z.number().optional(),
+  isRequired: z.boolean().optional(),
+  isHidden: z.boolean().optional(),
+  keepOnlyFirstWhenOtherSlotFilled: slotNameArraySchema.optional(),
+  clearWhenOtherSlotHasMultipleItems: slotNameArraySchema.optional(),
+  noMultipleIfSlotsFilled: slotNameArraySchema.optional(),
+  canAcceptDataIndependentOf: slotNameArraySchema.optional(),
+  activeWhenSubtype: z.array(z.string()).optional(),
+  options: z
+    .object({
+      isBinningDisabled: z.boolean().optional(),
+      isAggregationDisabled: z.boolean().optional(),
+      areGrandTotalsEnabled: z.boolean().optional(),
+      showOnlyFirstSlotGrandTotals: z.boolean().optional(),
+      isCumulativeSumEnabled: z.boolean().optional(),
+      areDatetimeOptionsEnabled: z.boolean().optional(),
+      showOnlyFirstSlotContentOptions: z.boolean().optional()
+    })
+    .strict()
+    .optional()
+} satisfies Record<keyof SlotConfig, z.ZodTypeAny>;
+
+export const SlotsConfigSchema: z.ZodType<SlotConfig[]> = z.array(
+  z.object(slotConfigShape).strict()
+);

--- a/scripts/validate-manifest.js
+++ b/scripts/validate-manifest.js
@@ -1,112 +1,78 @@
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+
+require('ts-node').register({
+  skipProject: true,
+  transpileOnly: true,
+  compilerOptions: {
+    esModuleInterop: true,
+    module: 'CommonJS',
+    moduleResolution: 'node',
+    target: 'ES2022'
+  }
+});
+
+const { SlotsConfigSchema } = require('../projects/builder/src/app/slot-schema.ts');
 
 const manifestPath = path.join(__dirname, '../projects/custom-chart/src/manifest.json');
-const customChartProjectPath = path.join(__dirname, '../projects/custom-chart');
 
-// Create a temporary TypeScript validation file
-const createValidatorScript = () => {
-  const tempDir = path.join(customChartProjectPath, 'temp');
-  const validatorPath = path.join(tempDir, 'validator.ts');
-
-  if (!fs.existsSync(tempDir)) {
-    fs.mkdirSync(tempDir, { recursive: true });
-  }
-  
-  // Hack - create TS file dynamically to avoid typescript import error in the JS file
-  const validatorContent = `
-import { SlotsConfigSchema } from '../../builder/src/app/slot-schema';
-import * as fs from 'fs';
-import * as path from 'path';
-
-// Path to the manifest file
-const manifestPath = '${manifestPath.replace(/\\/g, '\\\\')}';
-
-try {
-  // Check if manifest exists
-  if (!fs.existsSync(manifestPath)) {
-    console.error('Manifest file not found at', manifestPath);
-    process.exit(1);
+function formatValidationPath(segments, manifest) {
+  if (segments.length === 0) {
+    return 'manifest.slots';
   }
 
-  // Read and parse the manifest.json file
-  const manifestContent = fs.readFileSync(manifestPath, 'utf8');
-  const manifest = JSON.parse(manifestContent);
+  let formattedPath = 'slots';
+  let startIndex = 0;
+  const firstSegment = segments[0];
 
-  if (!manifest.slots || !Array.isArray(manifest.slots)) {
-    console.error('Invalid manifest: "slots" property must be an array');
-    process.exit(1);
-  }
-  
-  // Validate with zod schema
-  const result = SlotsConfigSchema.safeParse(manifest.slots);
-  
-  if (!result.success) {
-    const formattedErrors = result.error.errors.map(err => 
-      \`\${err.path.join('.')}: \${err.message}\`
-    ).join('\\n');
-    
-    console.error(\`Validation failed:\\n\${formattedErrors}\`);
-    process.exit(1);
-  }
-  
-  console.log('Manifest validation successful!');
-  process.exit(0);
-} catch (error: any) {
-  console.error('Error during validation:', error.message || String(error));
-  process.exit(1);
-}
-`;
+  if (typeof firstSegment === 'number') {
+    formattedPath += `[${firstSegment}]`;
 
-  fs.writeFileSync(validatorPath, validatorContent);
-  return validatorPath;
+    const slot = manifest.slots?.[firstSegment];
+    if (slot && typeof slot.name === 'string') {
+      formattedPath += ` ("${slot.name}")`;
+    }
+
+    startIndex = 1;
+  }
+
+  for (let index = startIndex; index < segments.length; index += 1) {
+    const segment = segments[index];
+    formattedPath += typeof segment === 'number' ? `[${segment}]` : `.${segment}`;
+  }
+
+  return formattedPath;
 }
 
 function validateManifest() {
   try {
     console.log('Validating manifest.json...');
-    
+
     if (!fs.existsSync(manifestPath)) {
       throw new Error(`manifest.json not found at ${manifestPath}`);
     }
-    
-    const validatorPath = createValidatorScript();
-    
-    try {
-      // Run the validator with ts-node
-      const result = execSync(`npx ts-node --skipProject ${validatorPath}`, { 
-        encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'pipe']
-      });
-      
-      console.log('✅', result.trim());
-      return true;
-    } catch (execError) {
-      let errorMessage = 'Unknown validation error';
-      
-      if (execError.stderr) {
-        // If there's stderr output, use that (may contain validation errors)
-        errorMessage = execError.stderr;
-      } else if (execError.stdout) {
-        // Otherwise check stdout
-        errorMessage = execError.stdout;
-      } else if (execError.message) {
-        // Finally fall back to the error message
-        errorMessage = execError.message;
-      }
-      
-      console.error('❌ Validation failed:', errorMessage);
+
+    const manifestContent = fs.readFileSync(manifestPath, 'utf8');
+    const manifest = JSON.parse(manifestContent);
+
+    if (!manifest.slots || !Array.isArray(manifest.slots)) {
+      console.error('❌ Manifest validation error: "slots" property must be an array');
       return false;
-    } finally {
-      // Clean up temp files
-      try {
-        const tempDir = path.join(customChartProjectPath, 'temp');
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      } catch (cleanupError) {
-        console.warn('Warning: Could not clean up temporary files:', cleanupError.message);
-      }
     }
+
+    const result = SlotsConfigSchema.safeParse(manifest.slots);
+
+    if (!result.success) {
+      const formattedErrors = result.error.errors
+        .map((err) => `${formatValidationPath(err.path, manifest)}: ${err.message}`)
+        .join('\n');
+
+      console.error(`❌ Validation failed:\n${formattedErrors}`);
+      return false;
+    }
+
+    console.log('✅ Manifest validation successful!');
+    return true;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('❌ Manifest validation error:', errorMessage);


### PR DESCRIPTION
The slot schema now tracks `SlotConfig` from `@luzmo/dashboard-contents-types`, accepts custom slot names, validates newly supported slot config fields, and rejects unknown keys. 

The manifest validator now loads the schema without creating a temporary TypeScript file and formats validation paths with more human readable information such as slot indexes and names, such as `slots[0] ("measureA").acceptableColumnTypes[0]`.

Example of succesful and failing validations:

<img width="1032" height="325" alt="image" src="https://github.com/user-attachments/assets/5b9c9b6f-2bed-486a-99b2-12e5aa83e9f4" />
