### PR TITLE
Fix data format for multi-query case

### DIFF
--- a/projects/builder/src/app/app.component.html
+++ b/projects/builder/src/app/app.component.html
@@ -152,6 +152,8 @@
 
               @let chartData = chartData$ | async;
 
+              @let queryPreviews = displayedQueryResults$ | async;
+
               @if (isQuerying) {
                 <div class="query-loader">
                   <div class="query-loader-label">Fetching data...</div>
@@ -175,22 +177,40 @@
 
                 } @else {
                   @if (queryInfo) {
-                    <p class="query-summary">
-                      Queried {{ queryInfo.rowCount }} rows in
-                      {{ queryInfo.durationInSeconds }} seconds:
-                    </p>
+                    <div class="query-summary">
+                      <p>
+                        Query results:
+                      </p>
+                    </div>
                   }
 
                   @if (chartData?.length > 0) {
-                    <ngx-json-viewer
-                      [json]="displayedChartData$ | async"
-                      [expanded]="false"
-                    ></ngx-json-viewer>
+                    @for (preview of queryPreviews ?? []; track preview.index) {
+                      <div class="query-preview">
+                        <div class="query-preview-header">
+                          <span class="query-summary-label">
+                            Query {{ preview.index }}
+                          </span>
 
-                    @if (chartData.length > 25) {
-                      <p class="remaining-rows">
-                        ... and {{ chartData.length - 25 }} more rows.
-                      </p>
+                          <span>
+                            {{ queryInfo?.queries?.[preview.index - 1]?.rowCount ?? preview.rowCount }}
+                            rows in
+                            {{ queryInfo?.queries?.[preview.index - 1]?.durationInSeconds ?? 0 }}
+                            seconds
+                          </span>
+                        </div>
+
+                        <ngx-json-viewer
+                          [json]="preview.rows"
+                          [expanded]="false"
+                        ></ngx-json-viewer>
+
+                        @if (preview.remainingRows > 0) {
+                          <p class="remaining-rows">
+                            ... and {{ preview.remainingRows }} more rows.
+                          </p>
+                        }
+                      </div>
                     }
 
                   } @else {

--- a/projects/builder/src/app/app.component.scss
+++ b/projects/builder/src/app/app.component.scss
@@ -230,6 +230,39 @@
       font-weight: 400;
       color: var(--color-text-active);
       font-size: 0.875rem;
+
+      p {
+        margin: 0;
+      }
+
+      &-label {
+        color: var(--color-text-active);
+        font-weight: 500;
+        white-space: nowrap;
+      }
+    }
+
+    .query-preview {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      margin-bottom: 0.75rem;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+
+      &-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.25rem 0.5rem;
+        border: 0.0625rem solid var(--color-border);
+        border-radius: var(--border-radius-default);
+        background-color: var(--color-surface-alt-1);
+        font-size: 0.8125rem;
+      }
     }
 
     .empty-state {
@@ -259,6 +292,7 @@
     .remaining-rows {
       margin-top: 0.5rem;
       font-style: italic;
+      font-size: 0.875rem;
     }
 
     .error-state {

--- a/projects/builder/src/app/app.component.ts
+++ b/projects/builder/src/app/app.component.ts
@@ -39,7 +39,7 @@ import {
   setUpSecureIframe
 } from './helpers/iframe.utils';
 import type { ItemData, ItemQuery, ItemQueryResponse, Theme } from './helpers/types';
-import { isDataResponse, isErrorResponse, normalizeQueryResponse } from './helpers/types';
+import { isDataResponse, isErrorResponse, normalizeQueryDataForRender, normalizeQueryResponse } from './helpers/types';
 import {
   CdkVirtualScrollViewport,
   ScrollingModule
@@ -671,11 +671,7 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewChecked {
                 this.queryResultInfoSubject.next({ rowCount, durationInSeconds });
               }
 
-              if (dataResults.length === 1) {
-                return dataResults[0].data;
-              }
-
-              return [dataResults.map((r) => r.data?.[0]?.[0])];
+              return normalizeQueryDataForRender(dataResults);
             }),
             catchError((error) => {
               console.error('Chart data query failed:', error);

--- a/projects/builder/src/app/app.component.ts
+++ b/projects/builder/src/app/app.component.ts
@@ -72,9 +72,23 @@ interface DatasetState {
   columns: BuilderDataField[];
 }
 
+interface QueryResultDetail {
+  index: number;
+  rowCount: number;
+  durationInSeconds: number;
+}
+
 interface QueryResultInfo {
   rowCount: number;
   durationInSeconds: number;
+  queries: QueryResultDetail[];
+}
+
+interface QueryResultPreview {
+  index: number;
+  rows: ItemData['data'];
+  rowCount: number;
+  remainingRows: number;
 }
 
 interface ChartThemeOption {
@@ -230,6 +244,7 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewChecked {
 
   chartData$!: Observable<any>;
   displayedChartData$!: Observable<any>;
+  displayedQueryResults$!: Observable<QueryResultPreview[]>;
   appearanceOptions = [
     { value: 'auto', label: 'Auto' },
     { value: 'light', label: 'Light' },
@@ -536,6 +551,34 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewChecked {
     this.displayedChartData$ = this.chartData$.pipe(
       map((data) => data.slice(0, 25)),
     );
+
+    this.displayedQueryResults$ = this.chartData$.pipe(
+      map((data) => this.buildQueryResultPreviews(data))
+    );
+  }
+
+  private buildQueryResultPreviews(
+    data: ItemData['data'] | ItemData['data'][]
+  ): QueryResultPreview[] {
+    if (!Array.isArray(data) || data.length === 0) {
+      return [];
+    }
+
+    const isMultiQueryResult = Array.isArray(data[0]) && Array.isArray(data[0][0]);
+    const queryRows: ItemData['data'][] = isMultiQueryResult
+      ? (data as ItemData['data'][])
+      : [data as ItemData['data']];
+
+    return queryRows.map((rows, index) => {
+      const displayedRows = rows.slice(0, 25);
+
+      return {
+        index: index + 1,
+        rows: displayedRows,
+        rowCount: rows.length,
+        remainingRows: Math.max(0, rows.length - displayedRows.length)
+      };
+    });
   }
 
   private toBuilderDataFields(fields: DatasetDataField[]): BuilderDataField[] {
@@ -655,21 +698,21 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewChecked {
                 return [];
               }
 
-              const performances = dataResults
-                .map((r) => r.performance)
-                .filter((p) => p != null);
-              if (performances.length > 0) {
-                const durationInSeconds =
-                  performances.reduce(
-                    (sum, p) => sum + this.calculateQueryDuration(p),
-                    0,
-                  ) / performances.length;
-                const rowCount =
-                  performances.reduce((sum, p) => sum + ((p as any).rows || 0), 0) ||
-                  (Array.isArray(dataResults[0].data) ? dataResults[0].data.length : 0);
+              const queryDetails = dataResults.map((result, index) => ({
+                index: index + 1,
+                rowCount: Array.isArray(result.data) ? result.data.length : 0,
+                durationInSeconds: this.calculateQueryDuration(result.performance)
+              }));
+              const rowCount = queryDetails.reduce((sum, detail) => sum + detail.rowCount, 0);
+              const durationInSeconds =
+                queryDetails.reduce((sum, detail) => sum + detail.durationInSeconds, 0) /
+                queryDetails.length;
 
-                this.queryResultInfoSubject.next({ rowCount, durationInSeconds });
-              }
+              this.queryResultInfoSubject.next({
+                rowCount,
+                durationInSeconds,
+                queries: queryDetails
+              });
 
               return normalizeQueryDataForRender(dataResults);
             }),

--- a/projects/builder/src/app/helpers/types.spec.ts
+++ b/projects/builder/src/app/helpers/types.spec.ts
@@ -1,6 +1,7 @@
 import {
   isDataResponse,
   isErrorResponse,
+  normalizeQueryDataForRender,
   normalizeQueryResponse,
   type ItemData,
   type ItemErrorResponse
@@ -64,6 +65,37 @@ describe('normalizeQueryResponse', () => {
     expect(result).toHaveLength(2);
     expect(isDataResponse(result[0])).toBe(true);
     expect(isErrorResponse(result[1])).toBe(true);
+  });
+});
+
+describe('normalizeQueryDataForRender', () => {
+  it('returns flat rows for a single-query response', () => {
+    const rows = [
+      ['2024-01-01T00:00:00.000Z', 4421921],
+      ['2024-02-01T00:00:00.000Z', 123]
+    ];
+
+    const result = normalizeQueryDataForRender([createDataResponse({ data: rows })]);
+
+    expect(result).toBe(rows);
+  });
+
+  it('preserves one row array per query for multi-query responses', () => {
+    const cohortRows = [
+      ['2024-01-01T00:00:00.000Z', 4421921],
+      ['2024-02-01T00:00:00.000Z', 3900000]
+    ];
+    const matrixRows = [
+      ['2024-01-01T00:00:00.000Z', '2024-01-01T00:00:00.000Z', 401391],
+      ['2024-01-01T00:00:00.000Z', '2024-02-01T00:00:00.000Z', 38112]
+    ];
+
+    const result = normalizeQueryDataForRender([
+      createDataResponse({ data: cohortRows, query_id: 'cohort-sizes' }),
+      createDataResponse({ data: matrixRows, query_id: 'cohort-matrix' })
+    ]);
+
+    expect(result).toEqual([cohortRows, matrixRows]);
   });
 });
 

--- a/projects/builder/src/app/helpers/types.ts
+++ b/projects/builder/src/app/helpers/types.ts
@@ -137,6 +137,14 @@ export function normalizeQueryResponse(
   return Array.isArray(response) ? response : [response];
 }
 
+export function normalizeQueryDataForRender(dataResponses: ItemData[]): ItemData['data'] | ItemData['data'][] {
+  if (dataResponses.length === 1) {
+    return dataResponses[0].data ?? [];
+  }
+
+  return dataResponses.map((response) => response.data ?? []);
+}
+
 export type ItemQuery = {
   dimensions: ItemQueryDimension[];
   measures: ItemQueryMeasure[];


### PR DESCRIPTION
## Describe your changes

### Problem

- Multi-query results were collapsed to `[dataResults.map((r) => r.data?.[0]?.[0])]` before being passed to the chart's render method, so only the first cell of the first row of each query reached the chart.
- Charts that depend on the full rows of every query (e.g. cohort matrix) therefore received malformed data and could not render correctly.
- The builder preview reused that same flattened shape, showing a single combined JSON viewer with one shared row count and duration and no per-query context.

### Solution

- Add a `normalizeQueryDataForRender` helper in `helpers/types.ts` that returns flat rows for a single-query response and an array of row arrays for multi-query responses, with unit tests covering both branches.
- Use the helper when forwarding query results to the render method so multi-query charts receive one row array per query.
- Track per-query `rowCount` and `durationInSeconds` on `QueryResultInfo`
- Add a `displayedQueryResults$` stream that emits one `QueryResultPreview` per query
- Update the builder template and styles to render a dedicated section per query with its own header, JSON viewer, and "... and N more rows" footer.


<img width="1714" height="1173" alt="image" src="https://github.com/user-attachments/assets/278d35d0-dff9-4b11-87ca-0d8d70c9c6f7" />
